### PR TITLE
Add Vercel deployment configuration for monorepo

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "builds": [
+    {
+      "src": "frontend/app/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    },
+    {
+      "src": "backend/main.py",
+      "use": "@vercel/python"
+    }
+  ],
+  "routes": [
+    { "src": "^/api/(.*)$", "dest": "backend/main.py" },
+    { "src": "^(?!/api/).*$", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added `vercel.json` configuration to deploy the Vite frontend and FastAPI backend as a single Vercel app
- Configured static builds for the React frontend with SPA routing support
- Set up Python runtime for FastAPI backend at `/api/*` endpoints

## Configuration Details
- Frontend served from root with deep-linking support via SPA rewrites
- Backend API accessible at `/api/*` using FastAPI with @vercel/python runtime
- Routes configured to prevent API requests from being intercepted by SPA rewrites

## Test plan
- [ ] Deploy to Vercel preview environment
- [ ] Verify frontend loads at root URL `/`
- [ ] Test SPA deep links work (e.g., `/flows/123`)
- [ ] Confirm API endpoints respond at `/api/health`
- [ ] Ensure no conflicts between frontend routes and API routes

🤖 Generated with [Claude Code](https://claude.ai/code)